### PR TITLE
pre-upgrade path should be relative to cwd

### DIFF
--- a/bin/liveswap
+++ b/bin/liveswap
@@ -101,7 +101,7 @@ else if (argv.s) {
 
   var preupgrade = argv['pre-upgrade']
   if (preupgrade) {
-    preupgrade = preupgrade.replace(/^\.[\\\/]/, process.cwd() + path.sep);
+    preupgrade = preupgrade.replace(/^\.[\\\/]/, process.cwd() + path.sep)
   }
 
   var opts = { 

--- a/bin/liveswap
+++ b/bin/liveswap
@@ -99,10 +99,15 @@ else if (argv.m) {
 }
 else if (argv.s) {
 
+  var preupgrade = argv['pre-upgrade']
+  if (preupgrade) {
+    preupgrade = preupgrade.replace(/^\.[\\\/]/, process.cwd() + path.sep);
+  }
+
   var opts = { 
     forks: argv.f,
     address: argv.a,
-    'pre-upgrade': argv['pre-upgrade'],
+    'pre-upgrade': preupgrade,
     target: path.resolve(argv.s)
   }
 


### PR DESCRIPTION
If I have liveswap installed globally and execute the following:

``` bash
$ liveswap -s script.js --pre-upgrade ./pull.js
```

It will look for `./pull.js` relative to the location of the liveswap module. It seems to me to make much more sense to make the location relative to `process.cwd()` when executed from the command prompt. This change is made in the bin script so as not to impact usage as a module. 
