### PR TITLE
make headpath configurable

### DIFF
--- a/bin/liveswap
+++ b/bin/liveswap
@@ -35,6 +35,9 @@ var args = require('optimist')
   .alias('s', 'start')
   .describe('s', '<path> start a node process cluster.')
 
+  .alias('H', 'head')
+  .describe('H', '<path> path to HEAD file')
+
 var argv = args.argv
 
 if (argv.h || argv.help || process.argv.length == 2) {
@@ -103,7 +106,8 @@ else if (argv.s) {
     forks: argv.f,
     address: argv.a,
     'pre-upgrade': argv['pre-upgrade'],
-    target: path.resolve(argv.s)
+    target: path.resolve(argv.s),
+    head: argv.head
   }
 
   if (argv.p) {

--- a/index.js
+++ b/index.js
@@ -25,6 +25,9 @@ module.exports = function(opts) {
   if (typeof opts == 'string') {
     opts = { target: opts }
   }
+  if (opts.head) {
+    headpath = opts.head
+  }
 
   if (!cluster.isMaster) {
     try {


### PR DESCRIPTION
If you have liveswap globally installed on a mac/linux and you run it without `sudo`, you'll get this error (or similar):

```
≫ liveswap -s instance/mmp-test-net.js --pre-upgrade ./lib/pull.js 

fs.js:427
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^
Error: EACCES, permission denied '/usr/local/lib/node_modules/liveswap/HEAD'
    at Object.fs.openSync (fs.js:427:18)
    at Object.fs.writeFileSync (fs.js:966:15)
    at writeHEAD (/usr/local/lib/node_modules/liveswap/index.js:20:13)
    at module.exports (/usr/local/lib/node_modules/liveswap/index.js:42:3)
    at Object.<anonymous> (/usr/local/lib/node_modules/liveswap/bin/liveswap:117:22)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
```

By making the headpath configurable with `-H, --head` you can now run globally installed liveswap without using `sudo`.
