### PR TITLE
Ability to run the pre-upgrade script without respawning the processes

### DIFF
--- a/bin/liveswap
+++ b/bin/liveswap
@@ -63,6 +63,9 @@ else if (argv.d) {
 else if (argv.m) {
   client.message(argv.m, done)
 }
+else if (argv['preupgrade']) {
+  client.preupgrade(null, done)
+}
 else if (argv.s) {
 
   var preupgrade = argv['pre-upgrade']

--- a/client.js
+++ b/client.js
@@ -57,4 +57,4 @@ exports.upgrade = function upgrade() { exec(arguments) }
 exports.kill = function kill() { exec(arguments) }
 exports.die = function die() { exec(arguments) }
 exports.message = function message() { exec(arguments) }
-
+exports.preupgrade = function preupgrade() { exec(arguments) }

--- a/index.js
+++ b/index.js
@@ -147,6 +147,17 @@ module.exports = function(opts) {
             sig('upgrade', data.value)
           break
 
+          case 'preupgrade':
+            if (opts['pre-upgrade']) {
+              return require(opts['pre-upgrade'])(data, function(err, value) {
+                if (err) {
+                  return ee.emit('log', { value: err, cmd: cmd })
+                }
+                ee.emit('log', { value: 'OK', cmd: cmd })
+              })
+            }
+          break
+
           case 'die':
             sig('die', null, true)
           break


### PR DESCRIPTION
Some apps are not cool with multiple processes and zero-downtime deploy does not work.  

This adds the ability to run the pre-upgrade script without actually upgrading.  Then you can do a restart.

command line usage example:

```
liveswap -f 1 -s ./run.js --pre-upgrade ./pre-upgrade.js  # start
liveswap --preupgrade                                     # run pre-upgrade script
liveswap -k                                               # restart
```

or programmatically:

```
// upgrade without zero-downtime
client.preupgrade({
  host: host
}, function(err) {
  if (err) return
  client.kill() // should we rename this to restart()?
})
```
