### PR TITLE
simplify die command logic, add -v, refactor sig() and broadcast()

### DIFF
--- a/bin/liveswap
+++ b/bin/liveswap
@@ -37,10 +37,18 @@ var args = require('optimist')
 
   .describe('z', 'disable zero-downtime, upgrade will kill processes')
 
+  .alias('v', 'version')
+  .describe('v', 'print program version and exit')
+
 var argv = args.argv
 
 if (argv.h || argv.help || process.argv.length == 2) {
   console.log(args.help())
+  process.exit(0)
+}
+
+if (argv.v) {
+  console.log(require('../package.json').version)
   process.exit(0)
 }
 

--- a/index.js
+++ b/index.js
@@ -44,13 +44,7 @@ module.exports = function(opts) {
 
   writeHEAD(opts.target)
 
-  function sig(cmd, value, norespawn) {
-    
-    if (norespawn) {
-      setTimeout(function() {
-        process.kill()
-      }, 1e3)
-    }
+  function sig(cmd, value) {
 
     var keys = Object.keys(cluster.workers)
 
@@ -75,16 +69,15 @@ module.exports = function(opts) {
             })
           }
         }
-        else {
-
+        else if (cmd === 'die') {
           cluster.workers[id].kill()
-
-          if (norespawn) {
-            if (index === keys.length-1) {
-              ee.emit('log', { value: 'OK', cmd: 'die' })
-            }
-            return
+          if (index === keys.length-1) {
+            ee.emit('log', { value: 'OK', cmd: 'die' })
+            process.kill()
           }
+        }
+        else {
+          cluster.workers[id].kill()
           cluster.fork()
         }
 
@@ -151,7 +144,7 @@ module.exports = function(opts) {
           break
 
           case 'die':
-            sig('die', null, true)
+            sig('die')
           break
 
           case 'kill':

--- a/index.js
+++ b/index.js
@@ -54,30 +54,30 @@ module.exports = function(opts) {
 
     function broadcast(keys) {
       keys.forEach(function(id, index) {
-
+        var worker = cluster.workers[id]
         if (cmd === 'message') {
-          cluster.workers[id].send(value)
+          worker.send(value)
         }
         else if (cmd === 'upgrade' && opts['zero-downtime']) {
           if (index % 2 === 0 && index !== keys.length-1) { 
             cluster.fork()
             setImmediate(function() {
-              cluster.workers[id].disconnect()
+              worker.disconnect()
             })
           }
           else {
-            cluster.workers[id].disconnect()
-            cluster.workers[id].on('disconnect', function() {
+            worker.disconnect()
+            worker.on('disconnect', function() {
               cluster.fork()
             })
           }
         }
         else if (cmd === 'upgrade') {
-          cluster.workers[id].kill()
+          worker.kill()
           cluster.fork()
         }
         else if (cmd === 'die') {
-          cluster.workers[id].kill()
+          worker.kill()
           if (index === keys.length-1) {
             reply(cmd)
             process.kill()

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ module.exports = function(opts) {
           worker.send(value)
         }
         else if (cmd === 'upgrade' && opts['zero-downtime']) {
-          if (index % 2 === 0 && index !== keys.length - 1) {
+          if (index % 2 === 0 && !isLast(index)) {
             cluster.fork()
             setImmediate(function() {
               worker.disconnect()
@@ -85,15 +85,15 @@ module.exports = function(opts) {
         }
         else if (cmd === 'die') {
           worker.kill()
-          if (index === keys.length - 1) {
+          if (isLast(index)) {
             reply(cmd)
             process.kill()
           }
         }
-        if (index === keys.length - 1) {
-          reply(cmd)
-        }
+        if (isLast(index)) { reply(cmd) }
       })
+
+      function isLast(i) { return i === keys.length - 1 }
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -60,6 +60,7 @@ module.exports = function(opts) {
 
     function broadcast() {
       var keys = Object.keys(cluster.workers)
+
       keys.forEach(function(id, index) {
         var worker = cluster.workers[id]
         if (cmd === 'message') {
@@ -90,8 +91,9 @@ module.exports = function(opts) {
             process.kill()
           }
         }
-        if (isLast(index)) { reply(cmd) }
       })
+
+      reply(cmd)
 
       function isLast(i) { return i === keys.length - 1 }
     }

--- a/index.js
+++ b/index.js
@@ -69,16 +69,16 @@ module.exports = function(opts) {
             })
           }
         }
+        else if (cmd === 'upgrade') {
+          cluster.workers[id].kill()
+          cluster.fork()
+        }
         else if (cmd === 'die') {
           cluster.workers[id].kill()
           if (index === keys.length-1) {
             ee.emit('log', { value: 'OK', cmd: 'die' })
             process.kill()
           }
-        }
-        else {
-          cluster.workers[id].kill()
-          cluster.fork()
         }
 
         if (index === keys.length-1) {

--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ module.exports = function(opts) {
             })
           }
         }
-        else if (cmd === 'upgrade') {
+        else if (cmd === 'upgrade' || cmd === 'kill') {
           worker.kill()
           cluster.fork()
         }


### PR DESCRIPTION
Since it was only a `sig('die')` that would cause `norespawn` to be true, we might as well remove `norespawn` and use the value of `cmd`. Also moved the `process.kill()` to after the last fork is killed.
