### PR TITLE
kill disconnected forks, restart crashed forks, number of cpus as default

### DIFF
--- a/bin/liveswap
+++ b/bin/liveswap
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 var path = require('path')
 var client = require('../client')
+var numCPUs = require('os').cpus().length
 
 var args = require('optimist')
   .alias('p', 'port')
@@ -12,7 +13,7 @@ var args = require('optimist')
   .describe('a', '<address> specify the ip address to run on.')
 
   .alias('f', 'forks')
-  .default('f', 2)
+  .default('f', numCPUs)
   .describe('f', '<number> specify how many worker processes to spawn')
 
   .alias('u', 'upgrade')

--- a/index.js
+++ b/index.js
@@ -48,6 +48,13 @@ module.exports = function(opts) {
 
   writeHEAD(opts.target)
 
+  cluster.on('exit', function(worker, code, signal) {
+    if (worker.suicide === true) return
+    console.error('a fork died, restarting! (%d/%d/%s)',
+                  worker.process.pid, code, signal)
+    cluster.fork()
+  })
+
   function sig(cmd, value) {
     if (cmd !== 'upgrade') return broadcast()
 

--- a/index.js
+++ b/index.js
@@ -81,16 +81,12 @@ module.exports = function(opts) {
         }
         else if (cmd === 'die') {
           worker.kill()
-          if (isLast(index)) {
-            reply(cmd)
-            process.kill()
-          }
         }
       })
 
       reply(cmd)
 
-      function isLast(i) { return i === keys.length - 1 }
+      if (cmd === 'die') process.kill()
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -66,8 +66,7 @@ module.exports = function(opts) {
     })
 
     function broadcast() {
-      Object.keys(cluster.workers).forEach(function(id, index) {
-        var worker = cluster.workers[id]
+      eachWorker(function(worker) {
         if (cmd === 'message') {
           worker.send(value)
         }
@@ -95,6 +94,12 @@ module.exports = function(opts) {
 
       if (cmd === 'die') process.kill()
     }
+  }
+
+  function eachWorker(cb) {
+    Object.keys(cluster.workers).forEach(function(id, index) {
+      cb(cluster.workers[id])
+    })
   }
 
   //


### PR DESCRIPTION
1. Make sure we still disconnect forks and wait until they are disconnected. Make sure to kill them to be sure the processes are really dead. We also kill a fork if the disconnect event takes too long. A possible enhancement of this would be to configure this time interval.
2. Currently we restart all forks that have crashed. This could also be configurable. Perhaps you want the forks to die out and simply kill liveswap when no forks are left, thus creating a crash early scenario. This might be preferrable in a development/staging environment, where you want to notice mistakes quick. However, in a live environment you might want the opposite and want to allow for some to crash but still keep it running.
3. I think default should use the number of cpus/threads the os can offer. Two as default might be bad if you're running your application on a single core, cheap ec2 machine. Also, if the default is number of cpus, you get automatic process scaling simply by running the software on a more powerful ec2 machine.
