### PR TITLE
make sure to reply back error to client if pre-upgrade fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,9 +127,8 @@ module.exports = function(opts) {
           case 'upgrade':
             if (opts['pre-upgrade']) {
               return require(opts['pre-upgrade'])(data, function(err, value) {
-                if (!err) {
-                  sig('upgrade', value || data.value || opts.target)
-                }
+                if (err) return reply(cmd, err)
+                sig('upgrade', value || data.value || opts.target)
               })
             }
             sig('upgrade', data.value)


### PR DESCRIPTION
Clients connecting to liveswap will hang if the pre-upgrade step fails.
