### PR TITLE
Fix cli for nonstandard port

### DIFF
--- a/bin/liveswap
+++ b/bin/liveswap
@@ -68,7 +68,9 @@ var opts = {
 };
 
 if (argv.u) {
-  opts.value: path.resolve(argv.u);
+  if ( typeof argv.u == 'string' ) {
+    opts.value = path.resolve(argv.u);
+  };
   client.upgrade(opts, done)
 }
 else if (argv.k) {
@@ -78,7 +80,7 @@ else if (argv.d) {
   client.die(opts, done);
 }
 else if (argv.m) {
-  opts.value: argv.m;
+  opts.value = argv.m;
   client.message(opts, done)
 }
 else if (argv.s) {

--- a/bin/liveswap
+++ b/bin/liveswap
@@ -62,17 +62,24 @@ var done = function(err, data) {
   process.exit(0)
 }
 
+var opts = {
+  host: argv.a,
+  port: argv.p
+};
+
 if (argv.u) {
-  client.upgrade(argv.u, done)
+  opts.value: path.resolve(argv.u);
+  client.upgrade(opts, done)
 }
 else if (argv.k) {
-  client.kill(argv.k, done)
+  client.kill(opts, done)
 }
 else if (argv.d) {
-  client.die(null, done);
+  client.die(opts, done);
 }
 else if (argv.m) {
-  client.message(argv.m, done)
+  opts.value: argv.m;
+  client.message(opts, done)
 }
 else if (argv.s) {
 


### PR DESCRIPTION
pass command line arguments to the client.js calls. This fix incorporates the suggestion of issue #30 from pepoviola and extends this to all other commands too.
